### PR TITLE
feat(seed): create admin user on development startup

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { DynamicModule } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { LoggerModule } from 'nestjs-pino/LoggerModule';
 import { ApiModule } from './api/api.module';
+import { SeedModule } from './app/services/seed/seed.module';
 import { ServicesModule } from './app/services/services.module';
 import { UseCasesModule } from './app/use-cases/use-cases.module';
 import { getConfigValidation } from './config/config.schema';
@@ -52,6 +53,10 @@ export class AppModule {
       }),
       ApiModule,
     ];
+
+    if (process.env.NODE_ENV === 'development') {
+      imports.push(SeedModule);
+    }
 
     if (process.env.NODE_ENV !== 'test') {
       imports.push(

--- a/src/app/services/seed/seed.module.ts
+++ b/src/app/services/seed/seed.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { SeedService } from './seed.service';
+
+@Module({
+  providers: [SeedService],
+})
+export class SeedModule {}

--- a/src/app/services/seed/seed.service.ts
+++ b/src/app/services/seed/seed.service.ts
@@ -1,0 +1,42 @@
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { DOMAIN_TOKENS } from '../../../domain/tokens';
+import { IUserRoleRepository } from '../../../domain/user/user-role.repository';
+import { Role } from '../../../domain/user/user-roles.entity';
+import { UserStatus } from '../../../domain/user/user-status.enum';
+import { User } from '../../../domain/user/user.entity';
+import { IUserRepository } from '../../../domain/user/user.repository';
+import { ICryptoService } from '../interfaces/crypto.interface';
+import { SERVICE_TOKENS } from '../tokens';
+
+@Injectable()
+export class SeedService implements OnApplicationBootstrap {
+  constructor(
+    @Inject(DOMAIN_TOKENS.USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
+    @Inject(DOMAIN_TOKENS.USER_ROLE_REPOSITORY)
+    private readonly userRoleRepository: IUserRoleRepository,
+    @Inject(SERVICE_TOKENS.CRYPTO_SERVICE)
+    private readonly cryptoService: ICryptoService,
+  ) {}
+
+  async onApplicationBootstrap() {
+    if (process.env.NODE_ENV !== 'development') return;
+
+    const adminEmail = 'admin@retex.pt';
+    const existing = await this.userRepository.findOne({ email: adminEmail });
+    if (existing) return;
+
+    const hashedPassword = await this.cryptoService.hashPassword('123456');
+    const user = await this.userRepository.create({
+      firstName: 'Admin',
+      lastName: 'Retex',
+      email: adminEmail,
+      contactPhone: '000000000',
+      documentNumber: '000000000',
+      password: hashedPassword,
+      status: UserStatus.ACTIVE,
+    });
+
+    await this.userRoleRepository.create({ user: user as User, role: Role.ADMIN });
+  }
+}


### PR DESCRIPTION
## Summary

- Cria `SeedService` que implementa `OnApplicationBootstrap` para semear um utilizador administrador no startup da aplicação
- O seed só corre quando `NODE_ENV=development`, garantindo que não afeta produção nem testes
- Verifica se `admin@retex.pt` já existe antes de criar, evitando duplicados
- O utilizador é criado com a role `ADMIN` e password `123456`

## Ficheiros

- `src/app/services/seed/seed.service.ts` — lógica de seeding
- `src/app/services/seed/seed.module.ts` — módulo NestJS
- `src/app.module.ts` — registo condicional do `SeedModule`

## Test plan

- [ ] Arrancar com `yarn dev` e confirmar que não há erros no startup
- [ ] `POST /auth/login` com `{ "email": "admin@retex.pt", "password": "123456" }` retorna token JWT com role `ADMIN`
- [ ] Reiniciar a aplicação — utilizador não é duplicado
- [ ] `yarn test` passa sem erros (seed não corre em `NODE_ENV=test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)