### PR TITLE
feat(user): sub-usuários com hierarquia plana

### DIFF
--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -1,15 +1,21 @@
-import { Body, Controller, Get, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Put, Query, Req, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
 import { AddRoleToUserUseCase } from '../../app/use-cases/user/add-role-to-user-use-case';
 import { AddRoleToUserDto } from '../../app/use-cases/user/add-role-to-user-use-case/add-role-to-user.dto';
+import { CreateSubUserUseCase } from '../../app/use-cases/user/create-sub-user-use-case';
+import { CreateSubUserDto } from '../../app/use-cases/user/create-sub-user-use-case/create-sub-user.dto';
 import { CreateUserUseCase } from '../../app/use-cases/user/create-user-use-case';
 import { CreateUserDto } from '../../app/use-cases/user/create-user-use-case/create-user.dto';
+import { DeactivateSubUserUseCase } from '../../app/use-cases/user/deactivate-sub-user-use-case';
 import { GetAllUsersUseCase } from '../../app/use-cases/user/get-all-users-use-case';
+import { GetSubUsersUseCase } from '../../app/use-cases/user/get-sub-users-use-case';
 import { GetUserByIdUseCase } from '../../app/use-cases/user/get-user-by-id-use-case';
 import { UpdateUserUseCase } from '../../app/use-cases/user/update-user-use-case';
 import { UpdateUserDto } from '../../app/use-cases/user/update-user-use-case/update-user.dto';
 import { Role } from '../../domain/user/user-roles.entity';
 import { User } from '../../domain/user/user.entity';
+import { JwtPayload } from '../../app/services/interfaces/auth.interface';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -23,15 +29,14 @@ export class UserController {
     private readonly getAllUsersUseCase: GetAllUsersUseCase,
     private readonly updateUserUseCase: UpdateUserUseCase,
     private readonly addRoleToUserUseCase: AddRoleToUserUseCase,
+    private readonly createSubUserUseCase: CreateSubUserUseCase,
+    private readonly getSubUsersUseCase: GetSubUsersUseCase,
+    private readonly deactivateSubUserUseCase: DeactivateSubUserUseCase,
   ) { }
 
   @Post()
   @ApiOperation({ summary: 'Criar novo usuário' })
-  @ApiResponse({
-    status: 201,
-    description: 'Usuário criado com sucesso',
-    type: Object
-  })
+  @ApiResponse({ status: 201, description: 'Usuário criado com sucesso', type: Object })
   @ApiResponse({ status: 409, description: 'Usuário já existe' })
   async createUser(@Body() createUserDto: CreateUserDto): Promise<Omit<User, 'password'>> {
     const user = await this.createUserUseCase.call(createUserDto);
@@ -45,14 +50,56 @@ export class UserController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Listar todos os usuários' })
   @ApiQuery({ name: 'role', required: false, enum: Role, description: 'Filtra usuários por role' })
-  @ApiResponse({
-    status: 200,
-    description: 'Lista de usuários',
-    type: Array
-  })
+  @ApiQuery({ name: 'parentId', required: false, type: String, description: 'Filtra sub-usuários por pai' })
+  @ApiResponse({ status: 200, description: 'Lista de usuários', type: Array })
   @ApiResponse({ status: 403, description: 'Acesso negado' })
-  async getAllUsers(@Query('role') role?: Role): Promise<Omit<User, 'password'>[]> {
-    return this.getAllUsersUseCase.call({ role });
+  async getAllUsers(
+    @Query('role') role?: Role,
+    @Query('parentId') parentId?: string,
+  ): Promise<Omit<User, 'password'>[]> {
+    return this.getAllUsersUseCase.call({ role, parentId });
+  }
+
+  @Get('me/sub-users')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Listar sub-usuários do usuário autenticado' })
+  @ApiResponse({ status: 200, description: 'Lista de sub-usuários', type: Array })
+  async getSubUsers(@Req() req: Request): Promise<Omit<User, 'password'>[]> {
+    const payload = req['user'] as JwtPayload;
+    return this.getSubUsersUseCase.call(payload.sub);
+  }
+
+  @Post('me/sub-users')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Criar sub-usuário para o usuário autenticado' })
+  @ApiResponse({ status: 201, description: 'Sub-usuário criado com sucesso', type: Object })
+  @ApiResponse({ status: 400, description: 'Sub-usuários não podem criar outros sub-usuários' })
+  @ApiResponse({ status: 409, description: 'Usuário já existe' })
+  async createSubUser(
+    @Req() req: Request,
+    @Body() dto: CreateSubUserDto,
+  ): Promise<Omit<User, 'password'>> {
+    const payload = req['user'] as JwtPayload;
+    const user = await this.createSubUserUseCase.call({ parentId: payload.sub, data: dto });
+    const { password, ...rest } = user;
+    return rest;
+  }
+
+  @Delete('me/sub-users/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Desativar sub-usuário do usuário autenticado' })
+  @ApiResponse({ status: 200, description: 'Sub-usuário desativado com sucesso', type: Object })
+  @ApiResponse({ status: 403, description: 'Acesso negado' })
+  @ApiResponse({ status: 404, description: 'Sub-usuário não encontrado' })
+  async deactivateSubUser(
+    @Req() req: Request,
+    @Param('id') subUserId: string,
+  ): Promise<Omit<User, 'password'>> {
+    const payload = req['user'] as JwtPayload;
+    return this.deactivateSubUserUseCase.call({ parentId: payload.sub, subUserId });
   }
 
   @Get(':id')
@@ -60,11 +107,7 @@ export class UserController {
   @Roles(Role.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Buscar usuário por ID' })
-  @ApiResponse({
-    status: 200,
-    description: 'Usuário encontrado',
-    type: Object
-  })
+  @ApiResponse({ status: 200, description: 'Usuário encontrado', type: Object })
   @ApiResponse({ status: 404, description: 'Usuário não encontrado' })
   @ApiResponse({ status: 403, description: 'Acesso negado' })
   async getUserById(@Param('id') id: string): Promise<Omit<User, 'password'>> {
@@ -78,17 +121,13 @@ export class UserController {
   @Roles(Role.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Atualizar usuário' })
-  @ApiResponse({
-    status: 200,
-    description: 'Usuário atualizado com sucesso',
-    type: Object
-  })
+  @ApiResponse({ status: 200, description: 'Usuário atualizado com sucesso', type: Object })
   @ApiResponse({ status: 404, description: 'Usuário não encontrado' })
   @ApiResponse({ status: 409, description: 'Email ou documento já em uso' })
   @ApiResponse({ status: 403, description: 'Acesso negado' })
   async updateUser(
     @Param('id') id: string,
-    @Body() updateUserDto: UpdateUserDto
+    @Body() updateUserDto: UpdateUserDto,
   ): Promise<Omit<User, 'password'>> {
     return this.updateUserUseCase.call({ id, data: updateUserDto });
   }
@@ -98,16 +137,12 @@ export class UserController {
   @Roles(Role.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Sincronizar roles do usuário (substitui as existentes pelas enviadas)' })
-  @ApiResponse({
-    status: 200,
-    description: 'Roles sincronizadas com sucesso',
-    type: Object
-  })
+  @ApiResponse({ status: 200, description: 'Roles sincronizadas com sucesso', type: Object })
   @ApiResponse({ status: 404, description: 'Usuário não encontrado' })
   @ApiResponse({ status: 403, description: 'Acesso negado - apenas ADMINs' })
   async addRoleToUser(
     @Param('id') userId: string,
-    @Body() addRoleDto: AddRoleToUserDto
+    @Body() addRoleDto: AddRoleToUserDto,
   ): Promise<Omit<User, 'password'>> {
     return this.addRoleToUserUseCase.call({ userId, data: addRoleDto });
   }

--- a/src/app/services/interfaces/auth.interface.ts
+++ b/src/app/services/interfaces/auth.interface.ts
@@ -4,6 +4,7 @@ export interface JwtPayload {
   sub: string;
   email: string;
   roles: string[];
+  parentId?: string;
   iat?: number;
   exp?: number;
 }

--- a/src/app/use-cases/auth/generate-jwt-use-case/index.ts
+++ b/src/app/use-cases/auth/generate-jwt-use-case/index.ts
@@ -13,6 +13,7 @@ export class GenerateJwtUseCase implements IUseCase<User, JwtResult> {
       sub: user.id,
       email: user.email,
       roles: user.roles.map(role => role.role),
+      ...(user.parentId && { parentId: user.parentId }),
     };
 
     const access_token = this.jwtService.sign(payload);

--- a/src/app/use-cases/interfaces/resolve-effective-user-id.ts
+++ b/src/app/use-cases/interfaces/resolve-effective-user-id.ts
@@ -1,0 +1,5 @@
+import { JwtPayload } from '../../services/interfaces/auth.interface';
+
+export function resolveEffectiveUserId(payload: JwtPayload): string {
+  return payload.parentId ?? payload.sub;
+}

--- a/src/app/use-cases/user/create-sub-user-use-case/create-sub-user-param.dto.ts
+++ b/src/app/use-cases/user/create-sub-user-use-case/create-sub-user-param.dto.ts
@@ -1,0 +1,6 @@
+import { CreateSubUserDto } from './create-sub-user.dto';
+
+export class CreateSubUserParamDto {
+  parentId: string;
+  data: CreateSubUserDto;
+}

--- a/src/app/use-cases/user/create-sub-user-use-case/create-sub-user.dto.ts
+++ b/src/app/use-cases/user/create-sub-user-use-case/create-sub-user.dto.ts
@@ -1,0 +1,28 @@
+import { IsEmail, IsNotEmpty, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class CreateSubUserDto {
+  @IsString({ message: 'Nome deve ser uma string' })
+  @IsNotEmpty({ message: 'Nome é obrigatório' })
+  firstName: string;
+
+  @IsString({ message: 'Sobrenome deve ser uma string' })
+  @IsNotEmpty({ message: 'Sobrenome é obrigatório' })
+  lastName: string;
+
+  @IsEmail({}, { message: 'Email deve ser válido' })
+  @IsNotEmpty({ message: 'Email é obrigatório' })
+  email: string;
+
+  @IsString({ message: 'Senha deve ser uma string' })
+  @IsNotEmpty({ message: 'Senha é obrigatória' })
+  @MinLength(6, { message: 'Senha deve ter pelo menos 6 caracteres' })
+  password: string;
+
+  @IsString()
+  @IsOptional()
+  contactPhone?: string;
+
+  @IsString()
+  @IsOptional()
+  documentNumber?: string;
+}

--- a/src/app/use-cases/user/create-sub-user-use-case/index.ts
+++ b/src/app/use-cases/user/create-sub-user-use-case/index.ts
@@ -1,0 +1,77 @@
+import { BadRequestException, ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { DOMAIN_TOKENS } from '../../../../domain/tokens';
+import { IUserRoleRepository } from '../../../../domain/user/user-role.repository';
+import { Role } from '../../../../domain/user/user-roles.entity';
+import { UserStatus } from '../../../../domain/user/user-status.enum';
+import { User } from '../../../../domain/user/user.entity';
+import { IUserRepository } from '../../../../domain/user/user.repository';
+import { ICryptoService } from '../../../services/interfaces/crypto.interface';
+import { ISanitizationService } from '../../../services/interfaces/sanitization.interface';
+import { SERVICE_TOKENS } from '../../../services/tokens';
+import { IUseCase } from '../../interfaces/use-case.interface';
+import { CreateSubUserParamDto } from './create-sub-user-param.dto';
+
+@Injectable()
+export class CreateSubUserUseCase implements IUseCase<CreateSubUserParamDto, User> {
+  constructor(
+    @Inject(DOMAIN_TOKENS.USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
+    @Inject(DOMAIN_TOKENS.USER_ROLE_REPOSITORY)
+    private readonly userRoleRepository: IUserRoleRepository,
+    @Inject(SERVICE_TOKENS.SANITIZATION_SERVICE)
+    private readonly sanitizationService: ISanitizationService,
+    @Inject(SERVICE_TOKENS.CRYPTO_SERVICE)
+    private readonly cryptoService: ICryptoService,
+  ) { }
+
+  async call(param: CreateSubUserParamDto): Promise<User> {
+    const { parentId, data } = param;
+
+    const parent = await this.userRepository.findOne({ id: parentId });
+    if (!parent) {
+      throw new NotFoundException('Usuário pai não encontrado');
+    }
+
+    if (parent.parentId) {
+      throw new BadRequestException('Sub-usuários não podem criar outros sub-usuários');
+    }
+
+    const existingByEmail = await this.userRepository.findOne({ email: data.email });
+    if (existingByEmail) {
+      throw new ConflictException('Usuário com este email já existe');
+    }
+
+    if (data.documentNumber) {
+      const sanitizedDocument = this.sanitizationService.sanitizeNumericString(data.documentNumber);
+      const existingByDocument = await this.userRepository.findOne({ documentNumber: sanitizedDocument });
+      if (existingByDocument) {
+        throw new ConflictException('Usuário com este documento já existe');
+      }
+      data.documentNumber = sanitizedDocument;
+    }
+
+    const hashedPassword = await this.cryptoService.hashPassword(data.password);
+
+    let user: Partial<User> = {
+      firstName: data.firstName,
+      lastName: data.lastName,
+      email: data.email,
+      contactPhone: data.contactPhone ?? null,
+      documentNumber: data.documentNumber ?? null,
+      password: hashedPassword,
+      status: UserStatus.ACTIVE,
+      parentId,
+    };
+
+    user = await this.userRepository.create(user);
+
+    const role = await this.userRoleRepository.create({
+      user: user as User,
+      role: Role.SUB_USER,
+    });
+
+    delete role.user;
+
+    return { ...user, roles: [role] } as User;
+  }
+}

--- a/src/app/use-cases/user/deactivate-sub-user-use-case/index.ts
+++ b/src/app/use-cases/user/deactivate-sub-user-use-case/index.ts
@@ -1,0 +1,40 @@
+import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { DOMAIN_TOKENS } from '../../../../domain/tokens';
+import { UserStatus } from '../../../../domain/user/user-status.enum';
+import { User } from '../../../../domain/user/user.entity';
+import { IUserRepository } from '../../../../domain/user/user.repository';
+import { IUseCase } from '../../interfaces/use-case.interface';
+
+export interface DeactivateSubUserParamDto {
+  parentId: string;
+  subUserId: string;
+}
+
+@Injectable()
+export class DeactivateSubUserUseCase implements IUseCase<DeactivateSubUserParamDto, Omit<User, 'password'>> {
+  constructor(
+    @Inject(DOMAIN_TOKENS.USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
+  ) { }
+
+  async call(param: DeactivateSubUserParamDto): Promise<Omit<User, 'password'>> {
+    const { parentId, subUserId } = param;
+
+    const subUser = await this.userRepository.findOne({ id: subUserId });
+    if (!subUser) {
+      throw new NotFoundException('Sub-usuário não encontrado');
+    }
+
+    if (subUser.parentId !== parentId) {
+      throw new ForbiddenException('Acesso negado');
+    }
+
+    const [updated] = await this.userRepository.update(
+      { id: subUserId },
+      { status: UserStatus.INACTIVE },
+    );
+
+    const { password, ...rest } = updated;
+    return rest;
+  }
+}

--- a/src/app/use-cases/user/get-all-users-use-case/index.ts
+++ b/src/app/use-cases/user/get-all-users-use-case/index.ts
@@ -5,7 +5,7 @@ import { User } from '../../../../domain/user/user.entity';
 import { IUserRepository } from '../../../../domain/user/user.repository';
 import { IUseCase } from '../../interfaces/use-case.interface';
 
-export interface GetAllUsersParamDto { role?: Role }
+export interface GetAllUsersParamDto { role?: Role; parentId?: string }
 
 @Injectable()
 export class GetAllUsersUseCase implements IUseCase<GetAllUsersParamDto, Omit<User, 'password'>[]> {
@@ -15,11 +15,11 @@ export class GetAllUsersUseCase implements IUseCase<GetAllUsersParamDto, Omit<Us
   ) { }
 
   async call(param?: GetAllUsersParamDto): Promise<Omit<User, 'password'>[]> {
-    const users = await this.userRepository.findWithRelations({}, { role: param?.role });
+    const query: Partial<User> = {};
+    if (param?.parentId) query.parentId = param.parentId;
 
-    return users.map(user => {
-      const { password, ...userWithoutPassword } = user;
-      return userWithoutPassword;
-    });
+    const users = await this.userRepository.findWithRelations(query, { role: param?.role });
+
+    return users.map(({ password, ...rest }) => rest);
   }
 } 

--- a/src/app/use-cases/user/get-sub-users-use-case/index.ts
+++ b/src/app/use-cases/user/get-sub-users-use-case/index.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DOMAIN_TOKENS } from '../../../../domain/tokens';
+import { User } from '../../../../domain/user/user.entity';
+import { IUserRepository } from '../../../../domain/user/user.repository';
+import { IUseCase } from '../../interfaces/use-case.interface';
+
+@Injectable()
+export class GetSubUsersUseCase implements IUseCase<string, Omit<User, 'password'>[]> {
+  constructor(
+    @Inject(DOMAIN_TOKENS.USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
+  ) { }
+
+  async call(parentId: string): Promise<Omit<User, 'password'>[]> {
+    const subUsers = await this.userRepository.find({ parentId });
+    return subUsers.map(({ password, ...rest }) => rest);
+  }
+}

--- a/src/app/use-cases/user/index.ts
+++ b/src/app/use-cases/user/index.ts
@@ -1,6 +1,9 @@
 import { AddRoleToUserUseCase } from './add-role-to-user-use-case';
+import { CreateSubUserUseCase } from './create-sub-user-use-case';
 import { CreateUserUseCase } from './create-user-use-case';
+import { DeactivateSubUserUseCase } from './deactivate-sub-user-use-case';
 import { GetAllUsersUseCase } from './get-all-users-use-case';
+import { GetSubUsersUseCase } from './get-sub-users-use-case';
 import { GetUserByIdUseCase } from './get-user-by-id-use-case';
 import { UpdateUserUseCase } from './update-user-use-case';
 
@@ -10,11 +13,17 @@ export const USER_USE_CASES = [
   GetAllUsersUseCase,
   UpdateUserUseCase,
   AddRoleToUserUseCase,
+  CreateSubUserUseCase,
+  GetSubUsersUseCase,
+  DeactivateSubUserUseCase,
 ];
 
 export * from './add-role-to-user-use-case';
+export * from './create-sub-user-use-case';
 export * from './create-user-use-case';
+export * from './deactivate-sub-user-use-case';
 export * from './get-all-users-use-case';
+export * from './get-sub-users-use-case';
 export * from './get-user-by-id-use-case';
 export * from './update-user-use-case';
 

--- a/src/app/use-cases/user/update-user-use-case/index.ts
+++ b/src/app/use-cases/user/update-user-use-case/index.ts
@@ -1,5 +1,6 @@
 import { ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { DOMAIN_TOKENS } from '../../../../domain/tokens';
+import { UserStatus } from '../../../../domain/user/user-status.enum';
 import { User } from '../../../../domain/user/user.entity';
 import { IUserRepository } from '../../../../domain/user/user.repository';
 import { ISanitizationService } from '../../../services/interfaces/sanitization.interface';
@@ -49,10 +50,12 @@ export class UpdateUserUseCase implements IUseCase<UpdateUserParamDto, Omit<User
       }
     }
 
-    // Atualizar usuário
     const [updatedUser] = await this.userRepository.update({ id }, updateData);
 
-    // Remover senha do retorno
+    if (updateData.status === UserStatus.INACTIVE) {
+      await this.userRepository.update({ parentId: id }, { status: UserStatus.INACTIVE });
+    }
+
     const { password, ...userWithoutPassword } = updatedUser;
     return userWithoutPassword;
   }

--- a/src/domain/user/user-roles.entity.ts
+++ b/src/domain/user/user-roles.entity.ts
@@ -11,4 +11,5 @@ export enum Role {
   DRIVER = "DRIVER",
   OPS = "OPS",
   ADMIN = "ADMIN",
+  SUB_USER = "SUB_USER",
 }

--- a/src/domain/user/user.entity.ts
+++ b/src/domain/user/user.entity.ts
@@ -12,6 +12,9 @@ export interface User extends Entity {
   documentNumber: string;
   password: string;
   status: UserStatus;
+  parentId?: string;
+  parent?: User;
+  subUsers?: User[];
   packages?: Package[];
   routes?: Route[];
   roles: UserRole[];

--- a/src/infrastructure/data/typeorm/config/migrations/1779302473609-AddParentIdToUser.ts
+++ b/src/infrastructure/data/typeorm/config/migrations/1779302473609-AddParentIdToUser.ts
@@ -1,0 +1,54 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddParentIdToUser1779302473609 implements MigrationInterface {
+    name = 'AddParentIdToUser1779302473609'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "user"
+            ADD "parent_id" uuid
+        `);
+        await queryRunner.query(`
+            ALTER TYPE "public"."user_role_role_enum"
+            RENAME TO "user_role_role_enum_old"
+        `);
+        await queryRunner.query(`
+            CREATE TYPE "public"."user_role_role_enum" AS ENUM('USER', 'DRIVER', 'OPS', 'ADMIN', 'SUB_USER')
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "user_role"
+            ALTER COLUMN "role" TYPE "public"."user_role_role_enum" USING "role"::"text"::"public"."user_role_role_enum"
+        `);
+        await queryRunner.query(`
+            DROP TYPE "public"."user_role_role_enum_old"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "user"
+            ADD CONSTRAINT "FK_acb096eef4d8b5acdd7acbb5c84" FOREIGN KEY ("parent_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "user" DROP CONSTRAINT "FK_acb096eef4d8b5acdd7acbb5c84"
+        `);
+        await queryRunner.query(`
+            CREATE TYPE "public"."user_role_role_enum_old" AS ENUM('USER', 'DRIVER', 'OPS', 'ADMIN')
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "user_role"
+            ALTER COLUMN "role" TYPE "public"."user_role_role_enum_old" USING "role"::"text"::"public"."user_role_role_enum_old"
+        `);
+        await queryRunner.query(`
+            DROP TYPE "public"."user_role_role_enum"
+        `);
+        await queryRunner.query(`
+            ALTER TYPE "public"."user_role_role_enum_old"
+            RENAME TO "user_role_role_enum"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "user" DROP COLUMN "parent_id"
+        `);
+    }
+
+}

--- a/src/infrastructure/data/typeorm/user/user.schema.ts
+++ b/src/infrastructure/data/typeorm/user/user.schema.ts
@@ -55,6 +55,11 @@ export const userSchema = new EntitySchema<User>({
       nullable: false,
       name: 'status',
     },
+    parentId: {
+      type: 'uuid',
+      nullable: true,
+      name: 'parent_id',
+    },
     ...BaseTimestampColumns,
   },
   relations: {
@@ -81,6 +86,19 @@ export const userSchema = new EntitySchema<User>({
         name: 'user_id',
       },
       inverseSide: 'user',
+    },
+    parent: {
+      type: 'many-to-one',
+      target: 'user',
+      joinColumn: {
+        name: 'parent_id',
+      },
+      nullable: true,
+    },
+    subUsers: {
+      type: 'one-to-many',
+      target: 'user',
+      inverseSide: 'parent',
     },
   },
   indices: [


### PR DESCRIPTION
## Summary

- Adiciona suporte a sub-usuários: qualquer usuário autenticado pode criar sub-usuários vinculados via `parentId`
- Sub-usuários autenticam com credenciais próprias mas operam nos recursos do pai (o `parentId` é incluído no JWT)
- Hierarquia plana — sub-usuários não podem criar outros sub-usuários
- Desativação do pai desativa todos os sub-usuários em cascata

## Endpoints novos

- `POST /user/me/sub-users` — cria sub-usuário
- `GET /user/me/sub-users` — lista sub-usuários do autenticado
- `DELETE /user/me/sub-users/:id` — desativa sub-usuário
- `GET /user?parentId=<id>` — filtro por pai (ADMIN)

## Test plan

- [ ] Criar usuário e sub-usuário, verificar que sub-usuário tem role `SUB_USER` e `parentId` no JWT
- [ ] Verificar que sub-usuário não pode criar outro sub-usuário (400)
- [ ] Verificar que desativar o pai desativa os sub-usuários em cascata
- [ ] Verificar que apenas o pai pode desativar seus próprios sub-usuários (403 para outros)
- [ ] Verificar filtro `?parentId` no `GET /user` (ADMIN)
- [ ] Aplicar migration em banco limpo e confirmar que não há erros