### PR TITLE
feat(dashboard): endpoint de estatísticas para dashboard admin

### DIFF
--- a/src/api/api.module.ts
+++ b/src/api/api.module.ts
@@ -9,6 +9,7 @@ import { RolesGuard } from './auth/guards/roles.guard';
 import { BlogCategoryController } from './blog-category/blog-category.controller';
 import { BlogPostController } from './blog-post/blog-post.controller';
 import { ContactController } from './contact/contact.controller';
+import { DashboardController } from './dashboard/dashboard.controller';
 import { FaqController } from './faq/faq.controller';
 import { TestZoneController } from './test-zone/test-zone.controller';
 import { BrandController } from './brand/brand.controller';
@@ -43,6 +44,7 @@ import { WelcomeController } from './welcome/welcome.controller';
     TestZoneController,
     FaqController,
     ContactController,
+    DashboardController,
   ],
   providers: [
     JwtAuthGuard,

--- a/src/api/dashboard/dashboard.controller.spec.ts
+++ b/src/api/dashboard/dashboard.controller.spec.ts
@@ -1,0 +1,31 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GetDashboardStatsUseCase } from '../../app/use-cases/dashboard/get-dashboard-stats-use-case';
+import { DashboardController } from './dashboard.controller';
+
+describe('DashboardController', () => {
+  let controller: DashboardController;
+  let getDashboardStatsUseCase: GetDashboardStatsUseCase;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DashboardController],
+      providers: [
+        { provide: GetDashboardStatsUseCase, useValue: { call: jest.fn() } },
+      ],
+    }).compile();
+
+    controller = module.get(DashboardController);
+    getDashboardStatsUseCase = module.get(GetDashboardStatsUseCase);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('delegates to the use-case', async () => {
+    const stats = { packages: { total: 1 } } as any;
+    (getDashboardStatsUseCase.call as jest.Mock).mockResolvedValue(stats);
+    expect(await controller.getStats()).toBe(stats);
+    expect(getDashboardStatsUseCase.call).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/api/dashboard/dashboard.controller.ts
+++ b/src/api/dashboard/dashboard.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get } from '@nestjs/common';
+import { GetDashboardStatsUseCase } from '../../app/use-cases/dashboard/get-dashboard-stats-use-case';
+import { Role } from '../../domain/user/user-roles.entity';
+import { Roles } from '../auth/decorators/roles.decorator';
+
+@Controller('dashboard')
+export class DashboardController {
+  constructor(
+    private readonly getDashboardStatsUseCase: GetDashboardStatsUseCase,
+  ) {}
+
+  @Get('stats')
+  @Roles(Role.ADMIN)
+  getStats() {
+    return this.getDashboardStatsUseCase.call();
+  }
+}

--- a/src/app/use-cases/dashboard/get-dashboard-stats-use-case/dashboard-stats.dto.ts
+++ b/src/app/use-cases/dashboard/get-dashboard-stats-use-case/dashboard-stats.dto.ts
@@ -1,0 +1,55 @@
+import { PackageStatus } from '../../../../domain/package/package.entity';
+
+export interface PackagesStats {
+  total: number;
+  totalWeightKg: number;
+  totalVolumes: number;
+  byStatus: { status: PackageStatus; count: number }[];
+  trend: { period: string; weightKg: number; count: number }[];
+}
+
+export interface DimensionStat {
+  key: string;
+  count: number;
+  quantity: number;
+}
+
+export interface TriageStats {
+  totalItems: number;
+  byQuality: DimensionStat[];
+  bySeason: DimensionStat[];
+  byType: DimensionStat[];
+  byBrand: { brand: string; count: number; quantity: number }[];
+}
+
+export interface EnvironmentStats {
+  landfillDivertedKg: number;
+  co2AvoidedKg: number;
+  waterSavedLiters: number;
+  factors: {
+    co2KgPerKg: number;
+    waterLitersPerKg: number;
+  };
+}
+
+export interface UsersStats {
+  /** Total de utilizadores registados. */
+  total: number;
+  /** Utilizadores com sessão válida (token não revogado e não expirado). */
+  active: number;
+  /** Utilizadores com conta marcada como ACTIVE (status da conta). */
+  statusActive: number;
+}
+
+export interface OutOfZoneStats {
+  totalPackages: number;
+  topCities: { city: string; count: number }[];
+}
+
+export interface DashboardStatsDto {
+  packages: PackagesStats;
+  triage: TriageStats;
+  environment: EnvironmentStats;
+  users: UsersStats;
+  outOfZone: OutOfZoneStats;
+}

--- a/src/app/use-cases/dashboard/get-dashboard-stats-use-case/index.spec.ts
+++ b/src/app/use-cases/dashboard/get-dashboard-stats-use-case/index.spec.ts
@@ -1,0 +1,79 @@
+import { Test } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
+import { IItemRepository } from '../../../../domain/item/item.repository';
+import { PackageStatus } from '../../../../domain/package/package.entity';
+import { IPackageRepository } from '../../../../domain/package/package.repository';
+import { DOMAIN_TOKENS } from '../../../../domain/tokens';
+import { IRefreshTokenRepository } from '../../../../domain/user/refresh-token.repository';
+import { UserStatus } from '../../../../domain/user/user-status.enum';
+import { IUserRepository } from '../../../../domain/user/user.repository';
+import { GetDashboardStatsUseCase } from '.';
+
+describe('GetDashboardStatsUseCase', () => {
+  const packageRepo = mock<IPackageRepository>();
+  const itemRepo = mock<IItemRepository>();
+  const userRepo = mock<IUserRepository>();
+  const refreshTokenRepo = mock<IRefreshTokenRepository>();
+  let useCase: GetDashboardStatsUseCase;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await Test.createTestingModule({
+      providers: [
+        GetDashboardStatsUseCase,
+        { provide: DOMAIN_TOKENS.PACKAGE_REPOSITORY, useValue: packageRepo },
+        { provide: DOMAIN_TOKENS.ITEM_REPOSITORY, useValue: itemRepo },
+        { provide: DOMAIN_TOKENS.USER_REPOSITORY, useValue: userRepo },
+        {
+          provide: DOMAIN_TOKENS.REFRESH_TOKEN_REPOSITORY,
+          useValue: refreshTokenRepo,
+        },
+      ],
+    }).compile();
+    useCase = module.get(GetDashboardStatsUseCase);
+  });
+
+  it('aggregates stats and derives environmental impact + totals', async () => {
+    packageRepo.getTotals.mockResolvedValue({
+      totalPackages: 5,
+      totalWeight: 100,
+      totalVolumes: 12,
+    });
+    packageRepo.countByStatus.mockResolvedValue([
+      { status: PackageStatus.CREATED, count: 3 },
+      { status: PackageStatus.OUT_OF_ZONE, count: 2 },
+    ]);
+    packageRepo.getWeightTrend.mockResolvedValue([
+      { period: '2026-06', weightKg: 100, count: 5 },
+    ]);
+    packageRepo.countOutOfZoneByCity.mockResolvedValue([
+      { city: 'Porto', count: 2 },
+    ]);
+    itemRepo.aggregateBy.mockImplementation(async (dimension) =>
+      dimension === 'quality'
+        ? [
+            { key: 'GOOD', count: 4, quantity: 8 },
+            { key: 'BAD', count: 1, quantity: 1 },
+          ]
+        : [],
+    );
+    itemRepo.aggregateByBrand.mockResolvedValue([
+      { brand: 'Nike', count: 3, quantity: 6 },
+    ]);
+    userRepo.countAll.mockResolvedValue(20);
+    userRepo.countByStatus.mockResolvedValue(15);
+    refreshTokenRepo.countActiveUsers.mockResolvedValue(7);
+
+    const result = await useCase.call();
+
+    expect(result.packages.total).toBe(5);
+    expect(result.packages.totalWeightKg).toBe(100);
+    expect(result.triage.totalItems).toBe(5);
+    expect(result.environment.co2AvoidedKg).toBe(100 * 3.6);
+    expect(result.environment.waterSavedLiters).toBe(100 * 10000);
+    expect(result.users).toEqual({ total: 20, active: 7, statusActive: 15 });
+    expect(result.outOfZone.totalPackages).toBe(2);
+    expect(result.outOfZone.topCities).toEqual([{ city: 'Porto', count: 2 }]);
+    expect(userRepo.countByStatus).toHaveBeenCalledWith(UserStatus.ACTIVE);
+  });
+});

--- a/src/app/use-cases/dashboard/get-dashboard-stats-use-case/index.ts
+++ b/src/app/use-cases/dashboard/get-dashboard-stats-use-case/index.ts
@@ -1,0 +1,106 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ENVIRONMENTAL_FACTORS } from '../../../../domain/dashboard/environmental-factors';
+import { IItemRepository } from '../../../../domain/item/item.repository';
+import { PackageStatus } from '../../../../domain/package/package.entity';
+import { IPackageRepository } from '../../../../domain/package/package.repository';
+import { DOMAIN_TOKENS } from '../../../../domain/tokens';
+import { IRefreshTokenRepository } from '../../../../domain/user/refresh-token.repository';
+import { UserStatus } from '../../../../domain/user/user-status.enum';
+import { IUserRepository } from '../../../../domain/user/user.repository';
+import { IUseCase } from '../../interfaces/use-case.interface';
+import { DashboardStatsDto } from './dashboard-stats.dto';
+
+const TREND_MONTHS = 12;
+const OUT_OF_ZONE_TOP_CITIES = 10;
+
+const round = (value: number, decimals = 2): number => {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+};
+
+@Injectable()
+export class GetDashboardStatsUseCase
+  implements IUseCase<void, DashboardStatsDto>
+{
+  constructor(
+    @Inject(DOMAIN_TOKENS.PACKAGE_REPOSITORY)
+    private readonly packageRepository: IPackageRepository,
+    @Inject(DOMAIN_TOKENS.ITEM_REPOSITORY)
+    private readonly itemRepository: IItemRepository,
+    @Inject(DOMAIN_TOKENS.USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
+    @Inject(DOMAIN_TOKENS.REFRESH_TOKEN_REPOSITORY)
+    private readonly refreshTokenRepository: IRefreshTokenRepository,
+  ) {}
+
+  async call(): Promise<DashboardStatsDto> {
+    const [
+      totals,
+      byStatus,
+      trend,
+      topCities,
+      byQuality,
+      bySeason,
+      byType,
+      byBrand,
+      usersTotal,
+      usersStatusActive,
+      usersActive,
+    ] = await Promise.all([
+      this.packageRepository.getTotals(),
+      this.packageRepository.countByStatus(),
+      this.packageRepository.getWeightTrend(TREND_MONTHS),
+      this.packageRepository.countOutOfZoneByCity(OUT_OF_ZONE_TOP_CITIES),
+      this.itemRepository.aggregateBy('quality'),
+      this.itemRepository.aggregateBy('season'),
+      this.itemRepository.aggregateBy('type'),
+      this.itemRepository.aggregateByBrand(),
+      this.userRepository.countAll(),
+      this.userRepository.countByStatus(UserStatus.ACTIVE),
+      this.refreshTokenRepository.countActiveUsers(),
+    ]);
+
+    const totalItems = byQuality.reduce((acc, row) => acc + row.count, 0);
+    const outOfZoneTotal =
+      byStatus.find((row) => row.status === PackageStatus.OUT_OF_ZONE)?.count ??
+      0;
+
+    const { CO2_KG_PER_KG, WATER_LITERS_PER_KG } = ENVIRONMENTAL_FACTORS;
+    const landfillDivertedKg = totals.totalWeight;
+
+    return {
+      packages: {
+        total: totals.totalPackages,
+        totalWeightKg: round(totals.totalWeight),
+        totalVolumes: totals.totalVolumes,
+        byStatus,
+        trend,
+      },
+      triage: {
+        totalItems,
+        byQuality,
+        bySeason,
+        byType,
+        byBrand,
+      },
+      environment: {
+        landfillDivertedKg: round(landfillDivertedKg),
+        co2AvoidedKg: round(landfillDivertedKg * CO2_KG_PER_KG),
+        waterSavedLiters: Math.round(landfillDivertedKg * WATER_LITERS_PER_KG),
+        factors: {
+          co2KgPerKg: CO2_KG_PER_KG,
+          waterLitersPerKg: WATER_LITERS_PER_KG,
+        },
+      },
+      users: {
+        total: usersTotal,
+        active: usersActive,
+        statusActive: usersStatusActive,
+      },
+      outOfZone: {
+        totalPackages: outOfZoneTotal,
+        topCities,
+      },
+    };
+  }
+}

--- a/src/app/use-cases/dashboard/index.ts
+++ b/src/app/use-cases/dashboard/index.ts
@@ -1,0 +1,5 @@
+import { GetDashboardStatsUseCase } from './get-dashboard-stats-use-case';
+
+export const DASHBOARD_USE_CASES = [GetDashboardStatsUseCase];
+
+export { GetDashboardStatsUseCase } from './get-dashboard-stats-use-case';

--- a/src/app/use-cases/use-cases.module.ts
+++ b/src/app/use-cases/use-cases.module.ts
@@ -8,6 +8,7 @@ import { BLOG_CATEGORY_USE_CASES } from './blog-category';
 import { BLOG_POST_USE_CASES } from './blog-post';
 import { BRAND_USE_CASES } from './brand';
 import { CONTACT_USE_CASES } from './contact';
+import { DASHBOARD_USE_CASES } from './dashboard';
 import { FAQ_USE_CASES } from './faq';
 import { TEST_ZONE_USE_CASES } from './test-zone';
 import { ITEM_USE_CASES } from './item/item.use-cases';
@@ -34,6 +35,7 @@ export class UseCasesModule {
       ...TEST_ZONE_USE_CASES,
       ...FAQ_USE_CASES,
       ...CONTACT_USE_CASES,
+      ...DASHBOARD_USE_CASES,
     ];
 
     return {

--- a/src/domain/dashboard/environmental-factors.ts
+++ b/src/domain/dashboard/environmental-factors.ts
@@ -1,0 +1,18 @@
+/**
+ * Fatores de conversão para estimar o impacto ambiental a partir do peso (kg)
+ * de têxtil desviado de aterro. São estimativas — valores configuráveis por env.
+ *
+ * - CO2_KG_PER_KG: kg de CO2e evitados por kg de têxtil reutilizado
+ *   (referências de reuso têxtil, ex. WRAP; varia ~3–25 conforme a peça).
+ * - WATER_LITERS_PER_KG: litros de água poupados por kg de têxtil evitado
+ *   (produção de algodão frequentemente citada em ~10.000–20.000 L/kg).
+ */
+const toNumber = (value: string | undefined, fallback: number): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+export const ENVIRONMENTAL_FACTORS = {
+  CO2_KG_PER_KG: toNumber(process.env.DASHBOARD_CO2_KG_PER_KG, 3.6),
+  WATER_LITERS_PER_KG: toNumber(process.env.DASHBOARD_WATER_LITERS_PER_KG, 10000),
+};

--- a/src/domain/item/item.repository.ts
+++ b/src/domain/item/item.repository.ts
@@ -1,7 +1,25 @@
 import { IRepository } from '../interfaces/repository.interface';
 import { Item } from './item.entity';
 
+export type ItemDimension = 'quality' | 'season' | 'type';
+
+export interface ItemDimensionCount {
+  key: string;
+  count: number;
+  quantity: number;
+}
+
+export interface ItemBrandCount {
+  brand: string;
+  count: number;
+  quantity: number;
+}
+
 export interface IItemRepository extends IRepository<Item> {
   findByIds(ids: string[]): Promise<Item[]>;
   findByPackageId(packageId: string): Promise<Item[]>;
-} 
+
+  // Agregações para o dashboard (somente leitura).
+  aggregateBy(dimension: ItemDimension): Promise<ItemDimensionCount[]>;
+  aggregateByBrand(): Promise<ItemBrandCount[]>;
+}

--- a/src/domain/package/package.repository.ts
+++ b/src/domain/package/package.repository.ts
@@ -11,6 +11,28 @@ export interface PackageFilters {
   collectTime?: string;
 }
 
+export interface PackageStatusCount {
+  status: PackageStatus;
+  count: number;
+}
+
+export interface PackageTotals {
+  totalPackages: number;
+  totalWeight: number;
+  totalVolumes: number;
+}
+
+export interface PackageTrendPoint {
+  period: string;
+  weightKg: number;
+  count: number;
+}
+
+export interface CityCount {
+  city: string;
+  count: number;
+}
+
 export interface IPackageRepository extends IRepository<Package> {
   findByFiltersWithPagination(
     filters: PackageFilters,
@@ -20,4 +42,10 @@ export interface IPackageRepository extends IRepository<Package> {
   findOneWithAllRelations(id: string): Promise<Package>;
   findByUser(userId: string): Promise<Package[]>;
   findAll(): Promise<Package[]>;
+
+  // Agregações para o dashboard (somente leitura).
+  countByStatus(): Promise<PackageStatusCount[]>;
+  getTotals(): Promise<PackageTotals>;
+  getWeightTrend(months: number): Promise<PackageTrendPoint[]>;
+  countOutOfZoneByCity(limit: number): Promise<CityCount[]>;
 }

--- a/src/domain/user/refresh-token.repository.ts
+++ b/src/domain/user/refresh-token.repository.ts
@@ -6,4 +6,7 @@ export interface IRefreshTokenRepository extends IRepository<RefreshToken> {
   findValidTokensByUserId(userId: string): Promise<RefreshToken[]>;
   revokeAllUserTokens(userId: string): Promise<void>;
   deleteExpiredTokens(): Promise<void>;
-} 
+
+  // Utilizadores com sessão válida (token não revogado e não expirado).
+  countActiveUsers(): Promise<number>;
+}

--- a/src/domain/user/user.repository.ts
+++ b/src/domain/user/user.repository.ts
@@ -1,5 +1,6 @@
 import { IRepository } from '../interfaces/repository.interface';
 import { Role } from './user-roles.entity';
+import { UserStatus } from './user-status.enum';
 import { User } from './user.entity';
 
 export interface IUserRepository extends IRepository<User> {
@@ -8,4 +9,8 @@ export interface IUserRepository extends IRepository<User> {
   findInactiveUsersByCity(sanitizedCity: string): Promise<User[]>;
   findByActivationToken(token: string): Promise<User | null>;
   findByResetToken(token: string): Promise<User | null>;
+
+  // Agregações para o dashboard (somente leitura).
+  countAll(): Promise<number>;
+  countByStatus(status: UserStatus): Promise<number>;
 }

--- a/src/infrastructure/data/typeorm/item/item.repository.ts
+++ b/src/infrastructure/data/typeorm/item/item.repository.ts
@@ -42,13 +42,23 @@ export class ItemRepository extends BaseRepository<Item> implements IItemReposit
 
   async aggregateBy(dimension: ItemDimension): Promise<ItemDimensionCount[]> {
     const repository = await this.getRepository();
-    // `dimension` é restrito pelo tipo ItemDimension — seguro para interpolar.
+    // Whitelist runtime: nunca interpolar `dimension` no SQL sem validar, pois o
+    // tipo é apagado em runtime (defesa contra valores inválidos / injeção).
+    const columns: Record<ItemDimension, string> = {
+      quality: 'quality',
+      season: 'season',
+      type: 'type',
+    };
+    const column = columns[dimension];
+    if (!column) {
+      throw new Error(`Dimensão de item inválida: ${dimension}`);
+    }
     const rows = await repository
       .createQueryBuilder('item')
-      .select(`item.${dimension}`, 'key')
+      .select(`item.${column}`, 'key')
       .addSelect('COUNT(*)', 'count')
       .addSelect('COALESCE(SUM(item.quantity), 0)', 'quantity')
-      .groupBy(`item.${dimension}`)
+      .groupBy(`item.${column}`)
       .getRawMany<{ key: string; count: string; quantity: string }>();
 
     return rows.map((row) => ({

--- a/src/infrastructure/data/typeorm/item/item.repository.ts
+++ b/src/infrastructure/data/typeorm/item/item.repository.ts
@@ -4,7 +4,12 @@ import { In, Repository } from 'typeorm';
 import { ILocalStorageService } from '../../../../app/services/local-storage/local-storage.service';
 import { SERVICE_TOKENS } from '../../../../app/services/tokens';
 import { Item } from '../../../../domain/item/item.entity';
-import { IItemRepository } from '../../../../domain/item/item.repository';
+import {
+  IItemRepository,
+  ItemBrandCount,
+  ItemDimension,
+  ItemDimensionCount,
+} from '../../../../domain/item/item.repository';
 import { BaseRepository } from '../abstraction/base.repository';
 import { itemSchema } from './item.schema';
 
@@ -34,4 +39,41 @@ export class ItemRepository extends BaseRepository<Item> implements IItemReposit
       relations: ['package', 'brand', 'storageUnit'],
     });
   }
-} 
+
+  async aggregateBy(dimension: ItemDimension): Promise<ItemDimensionCount[]> {
+    const repository = await this.getRepository();
+    // `dimension` é restrito pelo tipo ItemDimension — seguro para interpolar.
+    const rows = await repository
+      .createQueryBuilder('item')
+      .select(`item.${dimension}`, 'key')
+      .addSelect('COUNT(*)', 'count')
+      .addSelect('COALESCE(SUM(item.quantity), 0)', 'quantity')
+      .groupBy(`item.${dimension}`)
+      .getRawMany<{ key: string; count: string; quantity: string }>();
+
+    return rows.map((row) => ({
+      key: row.key,
+      count: Number(row.count),
+      quantity: Number(row.quantity),
+    }));
+  }
+
+  async aggregateByBrand(): Promise<ItemBrandCount[]> {
+    const repository = await this.getRepository();
+    const rows = await repository
+      .createQueryBuilder('item')
+      .leftJoin('item.brand', 'brand')
+      .select("COALESCE(brand.name, 'Sem marca')", 'brand')
+      .addSelect('COUNT(*)', 'count')
+      .addSelect('COALESCE(SUM(item.quantity), 0)', 'quantity')
+      .groupBy('brand.name')
+      .orderBy('COUNT(*)', 'DESC')
+      .getRawMany<{ brand: string; count: string; quantity: string }>();
+
+    return rows.map((row) => ({
+      brand: row.brand,
+      count: Number(row.count),
+      quantity: Number(row.quantity),
+    }));
+  }
+}

--- a/src/infrastructure/data/typeorm/package/package.repository.ts
+++ b/src/infrastructure/data/typeorm/package/package.repository.ts
@@ -7,10 +7,14 @@ import {
   PaginatedResult,
   PaginationParams,
 } from '../../../../domain/interfaces/pagination.interface';
-import { Package } from '../../../../domain/package/package.entity';
+import { Package, PackageStatus } from '../../../../domain/package/package.entity';
 import {
+  CityCount,
   IPackageRepository,
   PackageFilters,
+  PackageStatusCount,
+  PackageTotals,
+  PackageTrendPoint,
 } from '../../../../domain/package/package.repository';
 import { BaseRepository } from '../abstraction/base.repository';
 import { packageSchema } from './package.schema';
@@ -105,6 +109,83 @@ export class PackageRepository
       .leftJoinAndSelect('package.route', 'route')
       .orderBy('package.createdAt', 'DESC')
       .getMany();
+  }
+
+  async countByStatus(): Promise<PackageStatusCount[]> {
+    const repository = await this.getRepository();
+    const rows = await repository
+      .createQueryBuilder('package')
+      .select('package.status', 'status')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('package.status')
+      .getRawMany<{ status: PackageStatus; count: string }>();
+
+    return rows.map((row) => ({
+      status: row.status,
+      count: Number(row.count),
+    }));
+  }
+
+  async getTotals(): Promise<PackageTotals> {
+    const repository = await this.getRepository();
+    const row = await repository
+      .createQueryBuilder('package')
+      .select('COUNT(*)', 'totalPackages')
+      .addSelect('COALESCE(SUM(package.weight), 0)', 'totalWeight')
+      .addSelect('COALESCE(SUM(package.estimatedVolumes), 0)', 'totalVolumes')
+      .getRawOne<{
+        totalPackages: string;
+        totalWeight: string;
+        totalVolumes: string;
+      }>();
+
+    return {
+      totalPackages: Number(row?.totalPackages ?? 0),
+      totalWeight: Number(row?.totalWeight ?? 0),
+      totalVolumes: Number(row?.totalVolumes ?? 0),
+    };
+  }
+
+  async getWeightTrend(months: number): Promise<PackageTrendPoint[]> {
+    const repository = await this.getRepository();
+    const rows = await repository
+      .createQueryBuilder('package')
+      .select("to_char(date_trunc('month', package.createdAt), 'YYYY-MM')", 'period')
+      .addSelect('COALESCE(SUM(package.weight), 0)', 'weight')
+      .addSelect('COUNT(*)', 'count')
+      .where("package.createdAt >= now() - (:months * interval '1 month')", {
+        months: Math.max(0, months - 1),
+      })
+      .groupBy("date_trunc('month', package.createdAt)")
+      .orderBy("date_trunc('month', package.createdAt)", 'ASC')
+      .getRawMany<{ period: string; weight: string; count: string }>();
+
+    return rows.map((row) => ({
+      period: row.period,
+      weightKg: Number(row.weight),
+      count: Number(row.count),
+    }));
+  }
+
+  async countOutOfZoneByCity(limit: number): Promise<CityCount[]> {
+    const repository = await this.getRepository();
+    const rows = await repository
+      .createQueryBuilder('package')
+      .innerJoin('package.address', 'address')
+      .select('address.city', 'city')
+      .addSelect('COUNT(*)', 'count')
+      .where('package.status = :status', {
+        status: PackageStatus.OUT_OF_ZONE,
+      })
+      .groupBy('address.city')
+      .orderBy('COUNT(*)', 'DESC')
+      .limit(limit)
+      .getRawMany<{ city: string; count: string }>();
+
+    return rows.map((row) => ({
+      city: row.city,
+      count: Number(row.count),
+    }));
   }
 
   async findOneWithAllRelations(id: string): Promise<Package> {

--- a/src/infrastructure/data/typeorm/user/refresh-token.repository.ts
+++ b/src/infrastructure/data/typeorm/user/refresh-token.repository.ts
@@ -55,4 +55,17 @@ export class RefreshTokenRepository
       expiresAt: LessThan(new Date()),
     });
   }
-} 
+
+  async countActiveUsers(): Promise<number> {
+    const repository = await this.getRepository();
+    const row = await repository
+      .createQueryBuilder('rt')
+      .leftJoin('rt.user', 'u')
+      .select('COUNT(DISTINCT u.id)', 'count')
+      .where('rt.isRevoked = false')
+      .andWhere('rt.expiresAt > now()')
+      .getRawOne<{ count: string }>();
+
+    return Number(row?.count ?? 0);
+  }
+}

--- a/src/infrastructure/data/typeorm/user/user.repository.ts
+++ b/src/infrastructure/data/typeorm/user/user.repository.ts
@@ -77,4 +77,16 @@ export class UserRepository
       .where('u.resetToken = :token', { token })
       .getOne();
   }
+
+  async countAll(): Promise<number> {
+    const repository = await this.getRepository();
+    return repository.count();
+  }
+
+  async countByStatus(status: UserStatus): Promise<number> {
+    const repository = await this.getRepository();
+    return repository.count({
+      where: { status } as FindOptionsWhere<User>,
+    });
+  }
 }


### PR DESCRIPTION
## Resumo
Adiciona o endpoint **`GET /dashboard/stats`** (restrito a `ADMIN`) que agrega, numa única chamada, os indicadores do dashboard administrativo do portal.

## Indicadores
- **Coletas/Pacotes:** total, peso, volumes, breakdown por status e tendência mensal (últimos 12 meses).
- **Triagem/Itens:** por qualidade, estação, tipo e marca (COUNT + SUM de quantidade).
- **Impacto ambiental:** kg desviados de aterro, CO₂ evitado e água poupada — derivados do peso, com fatores configuráveis por env (`DASHBOARD_CO2_KG_PER_KG`, `DASHBOARD_WATER_LITERS_PER_KG`).
- **Utilizadores:** total, ativos (sessão válida via refresh token) e contas ativas.
- **Cidades fora da zona:** pacotes `OUT_OF_ZONE` agrupados por cidade.

## Implementação
- Segue a arquitetura hexagonal: `DashboardController` → `GetDashboardStatsUseCase` → métodos de agregação nos repositórios donos (package, item, user, refresh-token) com `createQueryBuilder` (COUNT/SUM/groupBy).
- **Sem migração** (apenas leitura sobre tabelas existentes).
- Testes unitários do use-case e do controller.

## Verificação
- `nest build` ok, `tsc --noEmit` limpo, testes do dashboard a passar (a falha pré-existente em `activate-user-use-case` não está relacionada).
- Smoke test: `GET /dashboard/stats` com token ADMIN → 200; sem ADMIN → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)